### PR TITLE
Fix failing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
 
 language: r
+cache: packages
 warnings_are_errors: true
 sudo: required
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,4 @@ notifications:
 
 after_success:
   - Rscript -e 'covr::codecov()'
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,6 @@ sudo: required
 r_github_packages:
   - jimhester/covr
 
-before_install:
-  - openssl aes-256-cbc
-      -K $encrypted_effddfd5c5ef_key -iv $encrypted_effddfd5c5ef_iv
-      -in tests/testthat/api_key.txt.enc -out ~/api_key.txt -d
-
 env:
  global:
    - CRAN: http://cran.rstudio.com
@@ -21,8 +16,6 @@ notifications:
   email:
     on_success: change
     on_failure: change
-
-
 
 after_success:
   - Rscript -e 'covr::codecov()'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,11 +26,11 @@ Imports:
     readr (>= 1.1.1),
     stringr (>= 1.2.0),
     tibble (>= 1.3.3),
-    tidyr (>= 0.6.3)
+    tidyr (>= 0.6.3),
+    timetk (>= 0.1.1.1)
 Suggests:
     tidyquant,
     tidyverse,
-    timetk,
     testthat,
     knitr
 RoxygenNote: 6.0.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,6 @@ Imports:
     httr (>= 1.2.1),
     jsonlite (>= 1.5),
     purrr (>= 0.2.2.2),
-    lubridate (>= 1.6.0),
     readr (>= 1.1.1),
     stringr (>= 1.2.0),
     tibble (>= 1.3.3),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,8 +29,6 @@ Imports:
     tidyr (>= 0.6.3),
     timetk (>= 0.1.1.1)
 Suggests:
-    tidyquant,
-    tidyverse,
     testthat,
     knitr
 RoxygenNote: 6.0.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,6 @@ LazyData: true
 Depends: 
     R (>= 3.3.0)
 Imports:
-    devtools (>= 1.12.0),
     dplyr (>= 0.7.0),
     glue (>= 1.1.1),
     httr (>= 1.2.1),

--- a/R/av_get.R
+++ b/R/av_get.R
@@ -86,6 +86,10 @@ av_get <- function(symbol = NULL, av_fun, ...) {
         } else {
             # Bad Call
 
+            if (is.null(symbol)) {
+                symbol <- "NULL"
+            }
+
             params_list <- list(symbol = symbol, av_fun = av_fun)
             dots$symbol <- NULL
             params_list <- c(params_list, dots)

--- a/tests/testthat/helpers_auth.R
+++ b/tests/testthat/helpers_auth.R
@@ -1,19 +1,18 @@
 # Auth helpers
 
-paths <- c("~/api_key.txt", "./tests/testthat/api_key.txt", "./api_key.txt")
-has_file <- unlist(purrr::map(paths, file.exists))
-path <- if (any(has_file)) {
-    paths[has_file][[1]]
-} else {
-    ""
-}
+# Developer:
+# Call `usethis::edit_r_environ()`
+# Add a line: `AV_API_KEY_TEST=<my-key>`
+# Save and restart R
 
-has_auth <- file.exists(path)
+maybe_key <- Sys.getenv("AV_API_KEY_TEST", unset = NA_character_)
 
 skip_if_no_auth <- function() {
-    if (!has_auth) {
+    if (is.na(maybe_key)) {
         skip("Authentication not available")
     }
 }
 
-if (has_auth) av_api_key(readLines(path))
+if (!is.na(maybe_key)) {
+    av_api_key(maybe_key)
+}

--- a/tests/testthat/helpers_auth.R
+++ b/tests/testthat/helpers_auth.R
@@ -16,3 +16,9 @@ skip_if_no_auth <- function() {
 if (!is.na(maybe_key)) {
     av_api_key(maybe_key)
 }
+
+# only 5 api calls per minute allowed
+delay_15_seconds <- function() {
+    Sys.sleep(15)
+}
+

--- a/tests/testthat/test_av_get.R
+++ b/tests/testthat/test_av_get.R
@@ -4,6 +4,7 @@ context("av_get() API interface")
 test_that("call TIMES_SERIES_INTRADAY", {
 
     skip_if_no_auth()
+    skip_on_cran()
 
     # Time Series Intraday
     symbol   <- "MSFT"
@@ -31,6 +32,7 @@ test_that("call TIMES_SERIES_INTRADAY", {
 test_that("call SECTOR", {
 
     skip_if_no_auth()
+    skip_on_cran()
 
     symbol   <- NULL
     av_fun   <- "SECTOR"
@@ -46,6 +48,7 @@ test_that("call SECTOR", {
 test_that("call Technical Indicators", {
 
     skip_if_no_auth()
+    skip_on_cran()
 
     # SMA
     symbol       <- "MSFT"
@@ -78,6 +81,7 @@ test_that("call Technical Indicators", {
 test_that("call results in error", {
 
     skip_if_no_auth()
+    skip_on_cran()
 
     symbol   <- NULL
     av_fun   <- "TIME_SERIES_DAILY"
@@ -89,6 +93,7 @@ test_that("call results in error", {
 test_that("call with no API key is stopped", {
 
     skip_if_no_auth()
+    skip_on_cran()
 
     key <- av_api_key()
 

--- a/tests/testthat/test_av_get.R
+++ b/tests/testthat/test_av_get.R
@@ -11,6 +11,7 @@ test_that("call TIMES_SERIES_INTRADAY", {
     av_fun   <- "TIME_SERIES_INTRADAY"
     interval <- "15min"
 
+    delay_15_seconds()
     resp <- av_get(symbol, av_fun, interval = interval)
 
     expect_s3_class(resp, "tbl")
@@ -20,6 +21,7 @@ test_that("call TIMES_SERIES_INTRADAY", {
     symbol   <- "MSFT"
     av_fun   <- "TIME_SERIES_DAILY_ADJUSTED"
 
+    delay_15_seconds()
     resp <- av_get(symbol, av_fun)
 
     expect_s3_class(resp, "tbl")
@@ -37,6 +39,7 @@ test_that("call SECTOR", {
     symbol   <- NULL
     av_fun   <- "SECTOR"
 
+    delay_15_seconds()
     resp <- av_get(symbol, av_fun)
 
     expect_s3_class(resp, "tbl")
@@ -57,6 +60,7 @@ test_that("call Technical Indicators", {
     time_period  <- 60
     series_type  <- "close"
 
+    delay_15_seconds()
     resp <- av_get(symbol, av_fun, interval = interval, time_period = time_period, series_type = series_type)
 
     expect_s3_class(resp, "tbl")
@@ -69,6 +73,7 @@ test_that("call Technical Indicators", {
     time_period  <- 60
     series_type  <- "close"
 
+    delay_15_seconds()
     resp <- av_get(symbol, av_fun, interval = interval, time_period = time_period, series_type = series_type)
 
     expect_s3_class(resp, "tbl")
@@ -82,10 +87,12 @@ test_that("call results in error", {
 
     skip_if_no_auth()
     skip_on_cran()
+    delay_15_seconds()
 
     symbol   <- NULL
     av_fun   <- "TIME_SERIES_DAILY"
 
+    delay_15_seconds()
     expect_error(av_get(symbol, av_fun))
 
 })
@@ -102,6 +109,7 @@ test_that("call with no API key is stopped", {
     symbol   <- "MSFT"
     av_fun   <- "TIME_SERIES_DAILY"
 
+    delay_15_seconds()
     expect_error(av_get(symbol, av_fun))
 
     av_api_key(key)


### PR DESCRIPTION
- API call tests now use `skip_on_cran()` so no one but us ever runs them
- API call tests now only run if a `AV_API_KEY_TEST` environment variable is present. This has been added to travis. To run the tests locally, call `usethis::edit_r_environ()` and add the env variable. The `helpers_auth.R` file describes what to do.
- To get around the 5 calls per 1 minute rate limit, API calls are now _tested_ 15 seconds apart.
- Fix a small warning with calling `stringi::stri_c()` will `NULL` as an input.
- Remove some unneeded imports 
- `timetk` is an Import as it is called from `av_get()`

Closes #7 
Closes #8 